### PR TITLE
Adding information about the ZFS cronjob to maintenance-tasks.md

### DIFF
--- a/docs/maintenance-tasks.md
+++ b/docs/maintenance-tasks.md
@@ -19,6 +19,6 @@ Additionally, there is a cron job on rooster that runs `sudo unattended-upgrade 
 * Frequency: monthly
 * Command: `sudo zpool scrub nest`
 
-To execute, you must first ssh into hen from rooster with the command `ssh hen`. Scrub checks the file system's integrity, and repairs any issues that it finds. After the scrub is finished, it is good to also run `zpool status` to check if there is anything wrong.
+To execute manually, you must first ssh into hen from rooster with the command `ssh hen`. Scrub checks the file system's integrity, and repairs any issues that it finds. After the scrub is finished, it is good to also run `zpool status` to check if there is anything wrong.
 
 This command is run on a cronjob, so there should be no need for manual intervention. The cronjob runs at 8:00AM the first day of every month. Rooster will also send out an email at 8:10AM on the same day with the results. If the scrub is fine, the email should be titled `[All clear] Hen monthly ZFS report`. If the title says `[POTENTIAL ZFS ISSUE]` instead, there may be something wrong with the disk, and the email contains the `zpool status` output which you can use to debug disk issues. Details on how the cronjob is setup are in the private configuration repo, under `cronjob/monthly-zfs-report.py`.

--- a/docs/maintenance-tasks.md
+++ b/docs/maintenance-tasks.md
@@ -19,5 +19,5 @@ Additionally, there is a cron job on rooster that runs `sudo unattended-upgrade 
 * Frequency: monthly
 * Command: `sudo zpool scrub nest`
 
-Scrub checks the file system's integrity, and repairs any issues that it finds. After the scrub is finished, it is good to also run `zpool status` to check if there is anything wrong.
+To execute, you must first ssh into hen from rooster with the command `ssh hen`. Scrub checks the file system's integrity, and repairs any issues that it finds. After the scrub is finished, it is good to also run `zpool status` to check if there is anything wrong.
 

--- a/docs/maintenance-tasks.md
+++ b/docs/maintenance-tasks.md
@@ -21,3 +21,4 @@ Additionally, there is a cron job on rooster that runs `sudo unattended-upgrade 
 
 To execute, you must first ssh into hen from rooster with the command `ssh hen`. Scrub checks the file system's integrity, and repairs any issues that it finds. After the scrub is finished, it is good to also run `zpool status` to check if there is anything wrong.
 
+This command is run on a cronjob, so there should be no need for manual intervention. The cronjob runs at 8:00AM the first day of every month. Rooster will also send out an email at 8:10AM on the same day with the results. If the scrub is fine, the email should be titled `[All clear] Hen monthly ZFS report`. If the title says `[POTENTIAL ZFS ISSUE]` instead, there may be something wrong with the disk, and the email contains the `zpool status` output which you can use to debug disk issues. Details on how the cronjob is setup are in the private configuration repo, under `cronjob/monthly-zfs-report.py`.


### PR DESCRIPTION
We have included information about the cronjob for scrubbing hen, and how to interpret the email which it sends out after each scrub.